### PR TITLE
Add total_steps parameter to training configuration and implement ste…

### DIFF
--- a/spectre/configs/dinov2_default.yaml
+++ b/spectre/configs/dinov2_default.yaml
@@ -22,6 +22,7 @@ train:
   log_freq: 1
 optim:
   epochs: 100
+  total_steps: 10
   weight_decay: 0.04
   weight_decay_end: 0.4
   base_lr: 0.004


### PR DESCRIPTION

This pull request introduces changes to the pretraining script and its configuration to enforce an optional maximum number of training steps (`total_steps`). The changes ensure that training stops once the specified step count is reached, even if the epoch is not completed. 

### Changes to training loop logic:
* Updated the training loop in `pretrain_dinov2.py` to include checks for `cfg.optim.total_steps`. If the global step count reaches this value, the training process exits both the inner and outer loops with appropriate log messages. [[1]](diffhunk://#diff-19f5de10f1934a72aba1e35bedeb20ccba897cf1998e2082667f1f208ba3ba33R328-R331) [[2]](diffhunk://#diff-19f5de10f1934a72aba1e35bedeb20ccba897cf1998e2082667f1f208ba3ba33R363-R366)

### Configuration updates:
* Added a new `total_steps` parameter under the `optim` section in `dinov2_default.yaml` to allow users to specify the maximum number of training steps.

### Minor code adjustments:
* Modified the data loader loop to include an `enumerate` for tracking batch indices, though the index is not currently used.