### PR TITLE
Steps

### DIFF
--- a/spectre/configs/dinov2_default.yaml
+++ b/spectre/configs/dinov2_default.yaml
@@ -22,6 +22,7 @@ train:
   log_freq: 1
 optim:
   epochs: 100
+  total_steps: 10
   weight_decay: 0.04
   weight_decay_end: 0.4
   base_lr: 0.004


### PR DESCRIPTION
This pull request introduces changes to the `pretrain_dinov2.py` script and its associated configuration file to add support for limiting the total number of training steps. The changes ensure that training can terminate early when a specified step limit is reached.

### Changes to training loop behavior:

* [`experiments/pretraining/pretrain_dinov2.py`](diffhunk://#diff-19f5de10f1934a72aba1e35bedeb20ccba897cf1998e2082667f1f208ba3ba33R328-R331): Modified the training loop to include checks for `cfg.optim.total_steps`. If the global step count exceeds this limit, the training process exits both the inner batch loop and the outer epoch loop with appropriate log messages. [[1]](diffhunk://#diff-19f5de10f1934a72aba1e35bedeb20ccba897cf1998e2082667f1f208ba3ba33R328-R331) [[2]](diffhunk://#diff-19f5de10f1934a72aba1e35bedeb20ccba897cf1998e2082667f1f208ba3ba33R363-R366)

### Configuration updates:

* [`spectre/configs/dinov2_default.yaml`](diffhunk://#diff-58ceb839544c6122f5b4a5fde26ab8bf03424576d9080dc374fcda9b2b01e47aR25): Added a new `total_steps` parameter under the `optim` section to define the maximum number of training steps.

### Minor improvements:

* [`experiments/pretraining/pretrain_dinov2.py`](diffhunk://#diff-19f5de10f1934a72aba1e35bedeb20ccba897cf1998e2082667f1f208ba3ba33R192-R198): Updated the batch loop to use `enumerate` for better tracking of batch indices, though the index is not yet used.