### PR TITLE
Refactor data loading in CTRateDataset and MerlinDataset, building report should be standard now

### DIFF
--- a/spectre/data/ct_rate.py
+++ b/spectre/data/ct_rate.py
@@ -20,18 +20,26 @@ class CTRateDataset(Dataset):
             import pandas as pd
             text_path = os.path.join(Path(data_dir), 'dataset', "radiology_text_reports", f"{subset}_reports.xlsx" )
             reports = pd.read_excel(text_path)
+            if subset == "train":
+                data = [{
+                    "image": str(image_path),
+                    "findings": [reports[reports["VolumeName"] == image_path.name]["Findings_EN"].values[0],
+                    reports[reports["VolumeName"] == image_path.name]["Findings_1"].values[0],
+                    reports[reports["VolumeName"] == image_path.name]["Findings_2"].values[0]],
 
-            data = [{
-                "image": str(image_path),
-                "findings": [reports[reports["VolumeName"] == image_path.name]["Findings_EN"].values[0],
-                reports[reports["VolumeName"] == image_path.name]["Findings_1"].values[0],
-                reports[reports["VolumeName"] == image_path.name]["Findings_2"].values[0]],
+                    "impressions": [reports[reports["VolumeName"] == image_path.name]["Impressions_EN"].values[0],
+                    reports[reports["VolumeName"] == image_path.name]["Impressions_1"].values[0],
+                    reports[reports["VolumeName"] == image_path.name]["Impressions_2"].values[0]],
 
-                "impressions": [reports[reports["VolumeName"] == image_path.name]["Impressions_EN"].values[0],
-                reports[reports["VolumeName"] == image_path.name]["Impressions_1"].values[0],
-                reports[reports["VolumeName"] == image_path.name]["Impressions_2"].values[0]],
+                } for image_path in image_paths]
+            else:
+                data = [{
+                    "image": str(image_path),
+                    "findings": [reports[reports["VolumeName"] == image_path.name]["Findings_EN"].values[0]],
 
-            } for image_path in image_paths]
+                    "impressions": [reports[reports["VolumeName"] == image_path.name]["Impressions_EN"].values[0]],
+
+                } for image_path in image_paths]
         else:
             data = [{"image": str(image_path)} for image_path in image_paths]
 
@@ -52,18 +60,26 @@ class CTRateCacheDataset(CacheDataset):
             import pandas as pd
             text_path = os.path.join(Path(data_dir), 'dataset', "radiology_text_reports", f"{subset}_reports.xlsx" )
             reports = pd.read_excel(text_path)
+            if subset == "train":
+                data = [{
+                    "image": str(image_path),
+                    "findings": [reports[reports["VolumeName"] == image_path.name]["Findings_EN"].values[0],
+                    reports[reports["VolumeName"] == image_path.name]["Findings_1"].values[0],
+                    reports[reports["VolumeName"] == image_path.name]["Findings_2"].values[0]],
 
-            data = [{
-                "image": str(image_path),
-                "findings": [reports[reports["VolumeName"] == image_path.name]["Findings_EN"].values[0],
-                reports[reports["VolumeName"] == image_path.name]["Findings_1"].values[0],
-                reports[reports["VolumeName"] == image_path.name]["Findings_2"].values[0]],
+                    "impressions": [reports[reports["VolumeName"] == image_path.name]["Impressions_EN"].values[0],
+                    reports[reports["VolumeName"] == image_path.name]["Impressions_1"].values[0],
+                    reports[reports["VolumeName"] == image_path.name]["Impressions_2"].values[0]],
 
-                "impressions": [reports[reports["VolumeName"] == image_path.name]["Impressions_EN"].values[0],
-                reports[reports["VolumeName"] == image_path.name]["Impressions_1"].values[0],
-                reports[reports["VolumeName"] == image_path.name]["Impressions_2"].values[0]],
+                } for image_path in image_paths]
+            else:
+                data = [{
+                    "image": str(image_path),
+                    "findings": [reports[reports["VolumeName"] == image_path.name]["Findings_EN"].values[0]],
 
-            } for image_path in image_paths]
+                    "impressions": [reports[reports["VolumeName"] == image_path.name]["Impressions_EN"].values[0]],
+
+                } for image_path in image_paths]
         else:
             data = [{"image": str(image_path)} for image_path in image_paths]
 

--- a/spectre/data/merlin.py
+++ b/spectre/data/merlin.py
@@ -27,19 +27,32 @@ class MerlinDataset(Dataset):
             reports[reports["study id"] == parse_name(p)]["Split"].values[0] == subset]
         
         if include_reports:
-            data = [{
-                "image": str(image_path),
-                "findings": [reports[reports["study id"] == parse_name(image_path)]["Findings_0"].values[0],
-                reports[reports["study id"] == parse_name(image_path)]["Findings_1"].values[0],
-                reports[reports["study id"] == parse_name(image_path)]["Findings_2"].values[0]],
 
-                "impressions": [reports[reports["study id"] == parse_name(image_path)]["Impressions_0"].values[0],
-                reports[reports["study id"] == parse_name(image_path)]["Impressions_1"].values[0],
-                reports[reports["study id"] == parse_name(image_path)]["Impressions_2"].values[0]],
+            if subset == "train":
 
-                "icd10": reports[reports["study id"] == parse_name(image_path)]["FULL_ICD10 Description"].values[0]
+                data = [{
+                    "image": str(image_path),
+                    "findings": [reports[reports["study id"] == parse_name(image_path)]["Findings_0"].values[0],
+                    reports[reports["study id"] == parse_name(image_path)]["Findings_1"].values[0],
+                    reports[reports["study id"] == parse_name(image_path)]["Findings_2"].values[0]],
 
-            } for image_path in image_paths]
+                    "impressions": [reports[reports["study id"] == parse_name(image_path)]["Impressions_0"].values[0],
+                    reports[reports["study id"] == parse_name(image_path)]["Impressions_1"].values[0],
+                    reports[reports["study id"] == parse_name(image_path)]["Impressions_2"].values[0]],
+
+                    "icd10": reports[reports["study id"] == parse_name(image_path)]["FULL_ICD10 Description"].values[0]
+
+                } for image_path in image_paths]
+
+            else:
+                data = [{
+                    "image": str(image_path),
+                    "findings": [reports[reports["study id"] == parse_name(image_path)]["Findings_0"].values[0]],
+                    "impressions": [reports[reports["study id"] == parse_name(image_path)]["Impressions_0"].values[0]],
+
+                    "icd10": reports[reports["study id"] == parse_name(image_path)]["FULL_ICD10 Description"].values[0]
+
+                } for image_path in image_paths]
         else:
             data = [{"image": str(image_path)} for image_path in image_paths]
 
@@ -62,19 +75,27 @@ class MerlinCacheDataset(CacheDataset):
             reports[reports["study id"] == parse_name(p)]["Split"].values[0] == subset]
         
         if include_reports:
-            data = [{
-                "image": str(image_path),
-                "findings": [reports[reports["study id"] == parse_name(image_path)]["Findings_0"].values[0],
-                reports[reports["study id"] == parse_name(image_path)]["Findings_1"].values[0],
-                reports[reports["study id"] == parse_name(image_path)]["Findings_2"].values[0]],
+            if subset == "train":
+                data = [{
+                    "image": str(image_path),
+                    "findings": [reports[reports["study id"] == parse_name(image_path)]["Findings_0"].values[0],
+                    reports[reports["study id"] == parse_name(image_path)]["Findings_1"].values[0],
+                    reports[reports["study id"] == parse_name(image_path)]["Findings_2"].values[0]],
 
-                "impressions": [reports[reports["study id"] == parse_name(image_path)]["Impressions_0"].values[0],
-                reports[reports["study id"] == parse_name(image_path)]["Impressions_1"].values[0],
-                reports[reports["study id"] == parse_name(image_path)]["Impressions_2"].values[0]],
+                    "impressions": [reports[reports["study id"] == parse_name(image_path)]["Impressions_0"].values[0],
+                    reports[reports["study id"] == parse_name(image_path)]["Impressions_1"].values[0],
+                    reports[reports["study id"] == parse_name(image_path)]["Impressions_2"].values[0]],
 
-                "icd10": reports[reports["study id"] == parse_name(image_path)]["FULL_ICD10 Description"].values[0]
+                    "icd10": reports[reports["study id"] == parse_name(image_path)]["FULL_ICD10 Description"].values[0]
 
-            } for image_path in image_paths]
+                } for image_path in image_paths]
+            else:
+                data = [{
+                    "image": str(image_path),
+                    "findings": [reports[reports["study id"] == parse_name(image_path)]["Findings_0"].values[0]],
+                    "impressions": [reports[reports["study id"] == parse_name(image_path)]["Impressions_0"].values[0]],
+                    "icd10": reports[reports["study id"] == parse_name(image_path)]["FULL_ICD10 Description"].values[0]
+                } for image_path in image_paths]
         else:
             data = [{"image": str(image_path)} for image_path in image_paths]
 

--- a/spectre/ssl/transforms/siglip_transform.py
+++ b/spectre/ssl/transforms/siglip_transform.py
@@ -86,41 +86,49 @@ class GenerateReportTransform(RandomizableTransform, MapTransform):
         if isinstance(icd10_codes, str):
             icd10_codes = icd10_codes.split(",")
         
-        # Ensure that we have at least three findings and impressions.
-        if len(findings) < 3:
-            raise ValueError("Expected at least 3 findings")
-        if len(impressions) < 3:
-            raise ValueError("Expected at least 3 impressions")
         
-        # Define weights for selecting the first 3 items.
-        weights = [
-            self.likelyhood_original,
-            (1 - self.likelyhood_original) / 2,
-            (1 - self.likelyhood_original) / 2,
-        ]
+        report = ""
         
         # Randomly select a finding and impression using weighted probabilities.
-        selected_finding = self.R.choice(findings[:3], p=weights)
-        selected_impression = self.R.choice(impressions[:3], p=weights)
+        if len(findings) > 0:
+            num_elements = len(findings)
+            weights = [self.likelyhood_original] + [(1 - self.likelyhood_original) / (num_elements - 1)] * (num_elements - 1)
+            selected_finding = self.R.choice(findings, p=weights)
         
-        # Draw a value between icd10_range_lower and 1.0 to determine the percentage of ICD10 codes to include.
-        icd10_percentage = self.R.uniform(self.icd10_range_lower, 1.0)
-        num_codes = int(len(icd10_codes) * icd10_percentage)
+            # Add finding to the report.
+            report += f"Findings: {selected_finding}\n"
+
+        if len(impressions) > 0:
+            num_elements = len(impressions)
+            weights = [self.likelyhood_original] + [(1 - self.likelyhood_original) / (num_elements - 1)] * (num_elements - 1)
+            # Select an impression based on the weights.
+            selected_impression = self.R.choice(impressions, p=weights)
+
+            # Add impression to the report.
+            report += f"Impressions: {selected_impression}\n"
+
+        # check if icd10_codes is empty or not
+        if icd10_codes:
+                
+            # Draw a value between icd10_range_lower and 1.0 to determine the percentage of ICD10 codes to include.
+            icd10_percentage = self.R.uniform(self.icd10_range_lower, 1.0)
+            num_codes = int(len(icd10_codes) * icd10_percentage)
         
-        if num_codes > 0:
-            # Ensure we do not exceed the available number of codes.
-            num_codes = min(num_codes, len(icd10_codes))
-            # Sample a subset of ICD10 codes without replacement.
-            selected_icd10 = self.R.choice(icd10_codes, size=num_codes, replace=False).tolist()
-        else:
-            selected_icd10 = []
+            if num_codes > 0:
+                # Ensure we do not exceed the available number of codes.
+                num_codes = min(num_codes, len(icd10_codes))
+                # Sample a subset of ICD10 codes without replacement.
+                selected_icd10 = self.R.choice(icd10_codes, size=num_codes, replace=False).tolist()
+            
+            # Add ICD10 codes to the report.
+            report += f"ICD10: {', '.join(selected_icd10)}\n"
         
         # Construct the final report string.
-        report = (
-            f"Findings: {selected_finding}\n"
-            f"Impressions: {selected_impression}\n"
-            f"ICD10: {', '.join(selected_icd10) if selected_icd10 else ''}"
-        )
+        # report = (
+        #     f"Findings: {selected_finding}\n"
+        #     f"Impressions: {selected_impression}\n"
+        #     f"ICD10: {', '.join(selected_icd10) if selected_icd10 else ''}"
+        # )
         
         data["report"] = report
         return data


### PR DESCRIPTION
This pull request introduces several updates to the data processing and transformation logic in the `spectre` module. The main changes include conditional handling of training subsets, enhanced report generation, and improved flexibility in selecting findings, impressions, and ICD10 codes. These updates aim to make the code more robust and adaptable to different dataset configurations.

### Conditional Data Handling by Subset
* Updated `__init__` methods in `spectre/data/ct_rate.py` and `spectre/data/merlin.py` to include conditional logic for handling training and non-training subsets. Training subsets now only include findings, while non-training subsets include findings, impressions, and ICD10 codes. (`spectre/data/ct_rate.py`: [[1]](diffhunk://#diff-389846dc1d0bb22683b7d28ee07a56fd1f914fa3eebc4f2a4c94524505816096L23-R23) [[2]](diffhunk://#diff-389846dc1d0bb22683b7d28ee07a56fd1f914fa3eebc4f2a4c94524505816096R36-R43) [[3]](diffhunk://#diff-389846dc1d0bb22683b7d28ee07a56fd1f914fa3eebc4f2a4c94524505816096L55-R63) [[4]](diffhunk://#diff-389846dc1d0bb22683b7d28ee07a56fd1f914fa3eebc4f2a4c94524505816096R76-R83); `spectre/data/merlin.py`: [[5]](diffhunk://#diff-ed4cbe40d50f4d60da7d9a6cf04fe33e7dfb34bb7a978664a8bce3fc5cfc310aR30-R32) [[6]](diffhunk://#diff-ed4cbe40d50f4d60da7d9a6cf04fe33e7dfb34bb7a978664a8bce3fc5cfc310aR46-R55) [[7]](diffhunk://#diff-ed4cbe40d50f4d60da7d9a6cf04fe33e7dfb34bb7a978664a8bce3fc5cfc310aR78) [[8]](diffhunk://#diff-ed4cbe40d50f4d60da7d9a6cf04fe33e7dfb34bb7a978664a8bce3fc5cfc310aR92-R98)

### Enhanced Report Generation
* Refactored the `__call__` method in `spectre/ssl/transforms/siglip_transform.py` to dynamically generate reports based on available findings, impressions, and ICD10 codes. This includes weighted selection of findings and impressions and appending ICD10 codes to the report only when they are present. [[1]](diffhunk://#diff-6f38ea927031b957a9321e0ac1f3261f4a798c6e26c252af71352a48a265bb9fL89-R111) [[2]](diffhunk://#diff-6f38ea927031b957a9321e0ac1f3261f4a798c6e26c252af71352a48a265bb9fL115-R131)…ally include findings and impressions based on the subset type