### PR TITLE
Clean text transform

### DIFF
--- a/spectre/ssl/transforms/siglip_transform.py
+++ b/spectre/ssl/transforms/siglip_transform.py
@@ -128,12 +128,5 @@ class GenerateReportTransform(RandomizableTransform, MapTransform):
             # Add ICD10 codes to the report.
             report += f"ICD10: {', '.join(selected_icd10)}\n"
         
-        # Construct the final report string.
-        # report = (
-        #     f"Findings: {selected_finding}\n"
-        #     f"Impressions: {selected_impression}\n"
-        #     f"ICD10: {', '.join(selected_icd10) if selected_icd10 else ''}"
-        # )
-        
         data["report"] = report
         return data


### PR DESCRIPTION
This pull request makes updates to the `__call__` method in `spectre/ssl/transforms/siglip_transform.py` to improve clarity and maintainability. The changes include refining a condition for checking non-empty lists and removing commented-out, redundant code.

### Improvements to code clarity and maintainability:

* Updated the condition for checking if `icd10_codes` is non-empty to use `len(icd10_codes) > 0` instead of relying on implicit truthiness, making the code more explicit. (`[spectre/ssl/transforms/siglip_transform.pyL116-R116](diffhunk://#diff-6f38ea927031b957a9321e0ac1f3261f4a798c6e26c252af71352a48a265bb9fL116-R116)`)
* Removed commented-out code that constructed a report string, as it was redundant and no longer necessary for the method's functionality. (`[spectre/ssl/transforms/siglip_transform.pyL131-L137](diffhunk://#diff-6f38ea927031b957a9321e0ac1f3261f4a798c6e26c252af71352a48a265bb9fL131-L137)`)