### PR TITLE
fix: use type() to build _BaseClass when MONAI is installed

### DIFF
--- a/src/spectre/ssl/transforms/dino_transform.py
+++ b/src/spectre/ssl/transforms/dino_transform.py
@@ -17,11 +17,11 @@ from spectre.transforms import RandScaleIntensityRange
 
 if transforms is not None:
     Compose = transforms.Compose
-    _BaseClass = (
+    _BaseClass = type("_BaseClass", (
         transforms.Randomizable,
         transforms.MapTransform,
         transforms.LazyTransform,
-    )
+    ), {})
 else:
     Compose = object  # type: ignore
     _BaseClass = object  # type: ignore

--- a/src/spectre/transforms/generate_report.py
+++ b/src/spectre/transforms/generate_report.py
@@ -11,7 +11,7 @@ except ImportError as e:
 
 
 if MONAI_IMPORT_ERROR is None:
-    _BaseClass = (Randomizable, MapTransform)
+    _BaseClass = type("_BaseClass", (Randomizable, MapTransform), {})
 else:
     _BaseClass = object
 

--- a/src/spectre/transforms/scale_intensity_range.py
+++ b/src/spectre/transforms/scale_intensity_range.py
@@ -18,7 +18,7 @@ except ImportError as e:
 
 
 if MONAI_IMPORT_ERROR is None:
-    _BaseClass = (Randomizable, Transform)
+    _BaseClass = type("_BaseClass", (Randomizable, Transform), {})
 else:
     _BaseClass = object
 


### PR DESCRIPTION
Fixes `import spectre` raising `TypeError: tuple expected at most 1 argument, got 3` when MONAI is installed on the `feature/minimal-deps` branch.

## Repro

```bash
python -m venv /tmp/spec && /tmp/spec/bin/pip install monai "git+https://github.com/cclaess/SPECTRE.git@feature/minimal-deps"
/tmp/spec/bin/python -c "import spectre"
```

## Cause

Three files use a conditional base-class pattern that assigns a tuple where a class is expected:

```python
if MONAI_IMPORT_ERROR is None:
    _BaseClass = (Randomizable, MapTransform)   # tuple, not a class
else:
    _BaseClass = object

class RandomReportTransformd(_BaseClass):   # TypeError
    ...
```

Python's `class X(<expr>):` treats `<expr>` as a single base, so `_BaseClass = (A, B)` is passed to the metaclass as a tuple-of-tuples, which it rejects. The fresh-venv install only passes because MONAI is absent and `_BaseClass` falls back to `object`.

Affects three classes:
- `RandomReportTransformd` (`src/spectre/transforms/generate_report.py`)
- `RandScaleIntensityRange` (`src/spectre/transforms/scale_intensity_range.py`)
- `DINORandomCropTransformd` (`src/spectre/ssl/transforms/dino_transform.py`)

## Fix

Build `_BaseClass` dynamically with `type()` so it is always a class:

```python
if MONAI_IMPORT_ERROR is None:
    _BaseClass = type("_BaseClass", (Randomizable, MapTransform), {})
else:
    _BaseClass = object
```

+4 / −4 across three files. MRO is preserved — verified `isinstance(r, MapTransform)` and `isinstance(r, Randomizable)`.

## Verification

- `import spectre` succeeds in an env with MONAI installed (was failing before).
- `RandomReportTransformd`, `RandScaleIntensityRange`, `DINORandomCropTransformd` all instantiate without error.
- A downstream wrapper of mine (importing `SpectreImageFeatureExtractor` + `MODEL_CONFIGS`) passes its 7 unit tests against this branch.

## Context

Refs #45, #46. This unblocks `pip install spectre-fm` from `feature/minimal-deps` in environments where MONAI is already present, which is my usecase.